### PR TITLE
Inferring Types & Fix structure for tRPC client

### DIFF
--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import Providers from "@client/lib/provider";
+import Providers from "@client/services/provider";
 
 const inter = Inter({ subsets: ["latin"] });
 

--- a/apps/client/src/components/views/home/Home/Home.tsx
+++ b/apps/client/src/components/views/home/Home/Home.tsx
@@ -5,7 +5,7 @@ import {
   Typography,
   typographyVariants,
 } from "@client/components/ui/base/Typography";
-import { trpc } from "@client/lib/trpc";
+import { trpc } from "@client/services/trpc";
 
 // const async Home = () => {
 const Home = () => {

--- a/apps/client/src/lib/trpc.ts
+++ b/apps/client/src/lib/trpc.ts
@@ -1,4 +1,0 @@
-import { createTRPCReact } from "@trpc/react-query";
-import type { AppRouter } from "@server/trpc/trpc.router";
-
-export const trpc = createTRPCReact<AppRouter>();

--- a/apps/client/src/services/hooks/useLinkById.ts
+++ b/apps/client/src/services/hooks/useLinkById.ts
@@ -1,0 +1,8 @@
+import { ReactQueryOptions, RouterInputs, trpc } from "@client/services/trpc";
+
+type LinkByIdOptions = ReactQueryOptions["link"]["byId"];
+type LinkByIdInput = RouterInputs["link"]["byId"];
+
+export function useLinkById(input: LinkByIdInput, options?: LinkByIdOptions) {
+  return trpc.link.byId.useQuery(input, options);
+}

--- a/apps/client/src/services/hooks/useLinkCreate.ts
+++ b/apps/client/src/services/hooks/useLinkCreate.ts
@@ -1,0 +1,22 @@
+import {
+  trpc,
+  type ReactQueryOptions,
+  type RouterInputs,
+  type RouterOutputs,
+} from "@client/services/trpc";
+
+type LinkCreateOptions = ReactQueryOptions["link"]["create"];
+
+export function useLinkCreate(options?: LinkCreateOptions) {
+  const utils = trpc.useUtils();
+
+  return trpc.link.create.useMutation({
+    ...options,
+    onSuccess(link) {
+      // invalidate all queries on the link router
+      // when a new link is created
+      utils.link.invalidate();
+      options?.onSuccess?.(link);
+    },
+  });
+}

--- a/apps/client/src/services/provider.tsx
+++ b/apps/client/src/services/provider.tsx
@@ -5,7 +5,7 @@ import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { ReactQueryStreamedHydration } from "@tanstack/react-query-next-experimental";
 import { httpBatchLink } from "@trpc/client";
-import { trpc } from "@client/lib/trpc";
+import { trpc } from "@client/services/trpc";
 import { useState } from "react";
 
 function Providers({ children }: React.PropsWithChildren) {

--- a/apps/client/src/services/trpc.ts
+++ b/apps/client/src/services/trpc.ts
@@ -1,0 +1,13 @@
+import {
+  createTRPCReact,
+  type inferReactQueryProcedureOptions,
+} from "@trpc/react-query";
+import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
+import type { AppRouter } from "@server/trpc/trpc.router";
+
+// infer the types for your router
+export type ReactQueryOptions = inferReactQueryProcedureOptions<AppRouter>;
+export type RouterInputs = inferRouterInputs<AppRouter>;
+export type RouterOutputs = inferRouterOutputs<AppRouter>;
+
+export const trpc = createTRPCReact<AppRouter>();


### PR DESCRIPTION
* Create folder for storing both trpc & react-query code (apps/client/src/services);
* Move `apps/client/src/lib/provider.tsx` to `apps/client/src/services/provider.tsx`;
* Move `apps/client/src/services/trpc.ts` to `apps/client/src/services/provider.tsx`;
* Create hooks for link: * apps/client/src/services/hooks/useLinkById.ts; * apps/client/src/services/hooks/useLinkCreate.ts;
* Fix imports (apps/client/src/app/layout.tsx, apps/client/src/components/views/home/Home/Home.tsx).