### PR TITLE
Integrate Bull Queue for Links

### DIFF
--- a/apps/client/src/components/views/home/Home/Home.tsx
+++ b/apps/client/src/components/views/home/Home/Home.tsx
@@ -8,19 +8,28 @@ import {
 import { useLinkCreate } from "@client/services/hooks/useLinkCreate";
 import { useLinkFindById } from "@client/services/hooks/useLinkFindById";
 import { useLinksFindAll } from "@client/services/hooks/useLinksFindAll";
+import { useLinksAnalyze } from "@client/services/hooks/useLinksAnalyze";
 
 const Home = () => {
   const linkCreate = useLinkCreate();
+  const linkAnalyze = useLinksAnalyze();
   const links = useLinksFindAll();
   const link = useLinkFindById({ id: 1 });
 
   console.log(link.data?.link);
   console.log(links.data?.links);
+
   const handleLinkCreate = () => {
     linkCreate.mutate({
       title: "Title",
       description: "Description",
       url: "URL",
+    });
+  };
+
+  const handleLinksAnalyze = () => {
+    linkAnalyze.mutate({
+      type: "test",
     });
   };
   return (
@@ -35,7 +44,10 @@ const Home = () => {
           github.com/caffellatte
         </Link>
         <button onClick={handleLinkCreate} disabled={linkCreate.isLoading}>
-          Login
+          Create link
+        </button>
+        <button onClick={handleLinksAnalyze} disabled={linkCreate.isLoading}>
+          Analyze links
         </button>
       </div>
     </main>

--- a/apps/client/src/services/hooks/useLinksAnalyze.ts
+++ b/apps/client/src/services/hooks/useLinksAnalyze.ts
@@ -5,12 +5,12 @@ import {
   type RouterOutputs,
 } from "@client/services/trpc";
 
-type LinkCreateOptions = ReactQueryOptions["linkCreate"];
+type LinksAnalyzeOptions = ReactQueryOptions["linksAnalyze"];
 
-export function useLinkCreate(options?: LinkCreateOptions) {
+export function useLinksAnalyze(options?: LinksAnalyzeOptions) {
   const utils = trpc.useUtils();
 
-  return trpc.linkCreate.useMutation({
+  return trpc.linksAnalyze.useMutation({
     ...options,
     onSuccess(data, variables, context) {
       // invalidate all queries on the link router

--- a/apps/server/src/links/links.module.ts
+++ b/apps/server/src/links/links.module.ts
@@ -2,9 +2,17 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { LinksService } from '@server/links/links.service';
 import { Link } from '@server/links/link.entity';
+import { LinksProcessor } from '@server/links/links.processor';
+import { BullModule } from '@nestjs/bull';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Link])],
-  providers: [LinksService],
+  imports: [
+    BullModule.registerQueue({
+      name: 'links',
+    }),
+    TypeOrmModule.forFeature([Link]),
+  ],
+  providers: [LinksService, LinksProcessor],
+  exports: [BullModule],
 })
 export class LinksModule {}

--- a/apps/server/src/links/links.processor.ts
+++ b/apps/server/src/links/links.processor.ts
@@ -1,0 +1,24 @@
+import { Process, Processor } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Link } from '@server/links/link.entity';
+
+@Processor('links')
+export class LinksProcessor {
+  constructor(
+    @InjectRepository(Link)
+    private linksRepository: Repository<Link>,
+  ) {}
+  private readonly logger = new Logger(LinksProcessor.name);
+
+  @Process('analyze')
+  async handleAnalyze(job: Job) {
+    this.logger.debug('Start Analyze...');
+    this.logger.debug(job.data);
+    const links = await this.linksRepository.find();
+    this.logger.debug(links);
+    this.logger.debug('FindOne Analyze');
+  }
+}

--- a/apps/server/src/trpc/trpc.router.ts
+++ b/apps/server/src/trpc/trpc.router.ts
@@ -24,6 +24,12 @@ export class TrpcRouter {
           greeting: `Hello ${name ? name : `Bilbo`}`,
         };
       }),
+    linksAnalyze: this.trpc.procedure
+      .input(z.object({ type: z.string() }))
+      .mutation(async ({ input }) => {
+        const { type } = input;
+        return await this.links.analyze(type);
+      }),
     linkCreate: this.trpc.procedure
       .input(
         z.object({


### PR DESCRIPTION
* Add 'links' BullQueue registration in imports, Add BullModule in exports & Add `LinksProcessor` in providers (apps/server/src/links/links.module.ts);
* Create `links` Processor, Add `analyze` Process &  Inject linksRepository (apps/server/src/links/links.processor.ts);
* Inject 'links' Queue in LinksService constructor & Create `analyze` handler for LinksService (apps/server/src/links/links.service.ts);
* Add `linksAnalyze` route tRPC (apps/server/src/trpc/trpc.router.ts);
* Fix useLinkCreate hook `onSuccess` (apps/client/src/services/hooks/useLinkCreate.ts);
* Create apps/client/src/services/hooks/useLinksAnalyze.ts;
* Implement `linkAnalyze` mutation (apps/client/src/components/views/home/Home/Home.tsx).