### PR TITLE
Add Server Side Calls Link Creation

### DIFF
--- a/apps/server/src/links/links.module.ts
+++ b/apps/server/src/links/links.module.ts
@@ -6,6 +6,8 @@ import { LinksProcessor } from '@server/links/links.processor';
 import { BullModule } from '@nestjs/bull';
 import { BullBoardModule } from '@bull-board/nestjs';
 import { BullAdapter } from '@bull-board/api/bullAdapter';
+import { TrpcRouter } from '@server/trpc/trpc.router';
+import { TrpcService } from '@server/trpc/trpc.service';
 
 @Module({
   imports: [
@@ -18,7 +20,7 @@ import { BullAdapter } from '@bull-board/api/bullAdapter';
     }),
     TypeOrmModule.forFeature([Link]),
   ],
-  providers: [LinksService, LinksProcessor],
+  providers: [LinksService, LinksProcessor, TrpcRouter, TrpcService],
   exports: [BullModule],
 })
 export class LinksModule {}

--- a/apps/server/src/links/links.processor.ts
+++ b/apps/server/src/links/links.processor.ts
@@ -4,20 +4,35 @@ import { Job } from 'bull';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Link } from '@server/links/link.entity';
+import { TrpcService } from '@server/trpc/trpc.service';
+import { TrpcRouter } from '@server/trpc/trpc.router';
 
 @Processor('links')
 export class LinksProcessor {
   constructor(
     @InjectRepository(Link)
     private linksRepository: Repository<Link>,
+    private readonly trpcRouter: TrpcRouter,
+    private readonly trpcService: TrpcService,
   ) {}
   private readonly logger = new Logger(LinksProcessor.name);
+
+  createCaller = this.trpcService.createCallerFactory(
+    this.trpcRouter.appRouter,
+  );
+
+  caller = this.createCaller({});
 
   @Process('analyze')
   async handleAnalyze(job: Job) {
     this.logger.debug('Start Analyze...');
     this.logger.debug(job.data);
     const links = await this.linksRepository.find();
+    this.caller.linkCreate({
+      title: 'title server side created',
+      description: 'description server side created',
+      url: 'url server side created',
+    });
     this.logger.debug(links);
     this.logger.debug('FindOne Analyze');
   }

--- a/apps/server/src/trpc/trpc.service.ts
+++ b/apps/server/src/trpc/trpc.service.ts
@@ -7,4 +7,5 @@ export class TrpcService {
   procedure = this.trpc.procedure;
   router = this.trpc.router;
   mergeRouters = this.trpc.mergeRouters;
+  createCallerFactory = this.trpc.createCallerFactory;
 }


### PR DESCRIPTION
* Create `createCallerFactory` in tRPC Service (apps/server/src/trpc/trpc.service.ts);
* Import `TrpcRouter` & `TrpcService` in LinksProcessor for creating server side call (apps/server/src/links/links.processor.ts);
* Import `TrpcRouter` & `TrpcService` as providers in LinksModule (apps/server/src/links/links.module.ts).