### PR TITLE
Implement `Bull` global events

### DIFF
--- a/apps/client/src/components/views/home/Home/Home.tsx
+++ b/apps/client/src/components/views/home/Home/Home.tsx
@@ -56,9 +56,10 @@ const Home = () => {
 
   const handleLinksAnalyze = () => {
     linkAnalyze.mutate({
-      type: "test",
+      type: "reports",
     });
   };
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-12">
       <div className="flex flex-col gap-3 text-center">

--- a/apps/server/src/links/links.processor.ts
+++ b/apps/server/src/links/links.processor.ts
@@ -4,14 +4,12 @@ import { Job } from 'bull';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Link } from '@server/links/link.entity';
-import { TrpcService } from '@server/trpc/trpc.service';
 
 @Processor('links')
 export class LinksProcessor {
   constructor(
     @InjectRepository(Link)
     private linksRepository: Repository<Link>,
-    private readonly trpcService: TrpcService,
   ) {}
   private readonly logger = new Logger(LinksProcessor.name);
 
@@ -20,8 +18,8 @@ export class LinksProcessor {
     this.logger.debug('Start Analyze...');
     this.logger.debug(job.data);
     const links = await this.linksRepository.find();
-    this.trpcService.ee.emit('update', { type: 'reports' });
-    this.logger.debug(links);
-    this.logger.debug('FindOne Analyze');
+    this.logger.debug(links.length);
+    this.logger.debug('End Analyze');
+    return job.data;
   }
 }

--- a/apps/server/src/trpc/trpc.module.ts
+++ b/apps/server/src/trpc/trpc.module.ts
@@ -8,10 +8,19 @@ import { Link } from '@server/links/link.entity';
 import { User } from '@server/users/user.entity';
 import { UsersModule } from '@server/users/users.module';
 import { UsersService } from '@server/users/users.service';
+import { BullModule } from '@nestjs/bull';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Link, User]), LinksModule, UsersModule],
+  imports: [
+    TypeOrmModule.forFeature([Link, User]),
+    BullModule.registerQueue({
+      name: 'links',
+    }),
+    LinksModule,
+    UsersModule,
+  ],
   controllers: [],
   providers: [TrpcService, TrpcRouter, LinksService, UsersService],
+  exports: [BullModule],
 })
 export class TrpcModule {}

--- a/apps/server/src/trpc/trpc.service.ts
+++ b/apps/server/src/trpc/trpc.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { initTRPC } from '@trpc/server';
-import { EventEmitter } from 'events';
 
 @Injectable()
 export class TrpcService {
@@ -9,5 +8,4 @@ export class TrpcService {
   router = this.trpc.router;
   mergeRouters = this.trpc.mergeRouters;
   createCallerFactory = this.trpc.createCallerFactory;
-  ee = new EventEmitter();
 }


### PR DESCRIPTION
* Replaced `EventEmitter` from `trpc.service` to `trpc.router` (apps/server/src/trpc/trpc.router.ts & apps/server/src/trpc/trpc.service.ts);
* Removed `trpcService`, add job data `return` (apps/server/src/links/links.processor.ts);
* Registered `links` queue & exports `BullModule` (apps/server/src/trpc/trpc.module.ts);
* Added `OnGlobalQueueCompleted` decorator & `onGlobalCompleted` handler (apps/server/src/trpc/trpc.router.ts);
* Fixed `handleLinksAnalyze` mutate options (apps/client/src/components/views/home/Home/Home.tsx).