### PR TITLE
Fix Refresh JWT Tokens

### DIFF
--- a/apps/client/src/services/utils.ts
+++ b/apps/client/src/services/utils.ts
@@ -1,0 +1,49 @@
+import Cookies from "js-cookie";
+import { httpBatchLink } from "@trpc/client";
+import type { AppRouter } from "@server/trpc/trpc.router";
+import { createTRPCProxyClient } from "@trpc/react-query";
+
+export const trcpProxyClient = createTRPCProxyClient<AppRouter>({
+  links: [
+    httpBatchLink({
+      url: "http://localhost:4000/trpc",
+    }),
+  ],
+});
+
+export async function handleTrpcUnauthError(
+  res: Response,
+  url: RequestInfo | URL,
+  options: any
+) {
+  const { error } = await res.json();
+  const refreshToken = Cookies.get("refresh_token");
+  if (error.message === "jwt expired" && refreshToken) {
+    try {
+      const refreshResponse = await trcpProxyClient.refresh.query({
+        refresh_token: refreshToken,
+      });
+
+      const { access_token, refresh_token } = refreshResponse;
+      Cookies.set("access_token", access_token);
+      Cookies.set("refresh_token", refresh_token);
+
+      const { Authorization, ...headers } = options.headers;
+
+      return await fetch(url, {
+        ...options,
+        headers: {
+          ...headers,
+          authorization: access_token,
+        },
+      });
+    } catch (error) {
+      // Todo: navigate to login
+      Cookies.remove("access_token");
+      Cookies.remove("refresh_token");
+      return res;
+    }
+  }
+
+  return res;
+}

--- a/apps/server/src/config/jwt.config.ts
+++ b/apps/server/src/config/jwt.config.ts
@@ -6,7 +6,7 @@ export default registerAs('jwt', () => {
       process.env.JWT_ACCESS_SECRET ||
       'DO NOT USE THIS VALUE. INSTEAD, CREATE A COMPLEX SECRET AND KEEP IT SAFE OUTSIDE OF THE SOURCE CODE.',
     global: true,
-    signOptions: { expiresIn: '60s' },
+    signOptions: { expiresIn: '15m' },
     refreshSecret:
       process.env.JWT_REFRESH_SECRET ||
       'DO NOT USE THIS VALUE. INSTEAD, CREATE A COMPLEX SECRET AND KEEP IT SAFE OUTSIDE OF THE SOURCE CODE.',

--- a/apps/server/src/trpc/trpc.router.ts
+++ b/apps/server/src/trpc/trpc.router.ts
@@ -58,11 +58,11 @@ export class TrpcRouter {
         const payload = await this.auth.signIn(username, password);
         return payload;
       }),
-    refreshToken: this.trpc.procedure
+    refresh: this.trpc.procedure
       .input(z.object({ refresh_token: z.string() }))
       .query(async ({ input }) => {
         const { refresh_token } = input;
-        const payload = await this.auth.refreshToken(refresh_token);
+        const payload = await this.auth.refresh(refresh_token);
         return payload;
       }),
     hello: this.trpc.procedure


### PR DESCRIPTION
* Added custom fetcher that checks `401` status & handle it with `handleTrpcUnauthError` (apps/client/src/services/provider.tsx);
* Created `utils` for react-query with `trcpProxyClient` & `handleTrpcUnauthError` for refresh tokens  (apps/client/src/services/utils.ts);
* Fixed refresh token handler: update `signAsync` function arguments (apps/server/src/auth/auth.service.ts);
* Updated `access_token` expiresIn value (apps/server/src/config/jwt.config.ts);
* Renamed `refreshToken` to `refresh` route (apps/server/src/trpc/trpc.router.ts).