### PR TITLE
Merging tRPC router with child routers

### DIFF
--- a/apps/client/src/components/views/home/Home/Home.tsx
+++ b/apps/client/src/components/views/home/Home/Home.tsx
@@ -22,7 +22,7 @@ const Home = () => {
   // const links = useLinksFindAll();
   const link = useLinkFindById({ id: 1 });
   const utils = trpc.useUtils();
-  const infiniteLinks = trpc.infiniteLinks.useInfiniteQuery(
+  const infiniteLinks = trpc.hyperlinks.get.useInfiniteQuery(
     {
       limit: 5,
     },
@@ -57,7 +57,7 @@ const Home = () => {
       },
       onData(data) {
         console.log(data);
-        utils.linksFindAll.invalidate();
+        utils.hyperlinks.get.invalidate();
       },
     },
   );
@@ -70,7 +70,7 @@ const Home = () => {
       },
       onData(data) {
         console.log(data);
-        utils.linksFindAll.invalidate();
+        utils.hyperlinks.get.invalidate();
       },
     },
   );

--- a/apps/client/src/services/hooks/useLinkCreate.ts
+++ b/apps/client/src/services/hooks/useLinkCreate.ts
@@ -5,12 +5,12 @@ import {
   type RouterOutputs,
 } from "@client/services/trpc";
 
-type LinkCreateOptions = ReactQueryOptions["linkCreate"];
+type LinkCreateOptions = ReactQueryOptions["hyperlinks"]["create"];
 
 export function useLinkCreate(options?: LinkCreateOptions) {
   const utils = trpc.useUtils();
 
-  return trpc.linkCreate.useMutation({
+  return trpc.hyperlinks.create.useMutation({
     ...options,
     onSuccess(data, variables, context) {
       // invalidate all queries on the link router

--- a/apps/client/src/services/hooks/useLinkFindById.ts
+++ b/apps/client/src/services/hooks/useLinkFindById.ts
@@ -1,11 +1,11 @@
 import { ReactQueryOptions, RouterInputs, trpc } from "@client/services/trpc";
 
-type LinkByIdOptions = ReactQueryOptions["linkFindById"];
-type LinkByIdInput = RouterInputs["linkFindById"];
+type LinkByIdOptions = ReactQueryOptions["hyperlinks"]["findById"];
+type LinkByIdInput = RouterInputs["hyperlinks"]["findById"];
 
 export function useLinkFindById(
   input: LinkByIdInput,
-  options?: LinkByIdOptions
+  options?: LinkByIdOptions,
 ) {
-  return trpc.linkFindById.useQuery(input, options);
+  return trpc.hyperlinks.findById.useQuery(input, options);
 }

--- a/apps/client/src/services/hooks/useLinksAnalyze.ts
+++ b/apps/client/src/services/hooks/useLinksAnalyze.ts
@@ -5,12 +5,12 @@ import {
   type RouterOutputs,
 } from "@client/services/trpc";
 
-type LinksAnalyzeOptions = ReactQueryOptions["linksAnalyze"];
+type LinksAnalyzeOptions = ReactQueryOptions["hyperlinks"]["analyze"];
 
 export function useLinksAnalyze(options?: LinksAnalyzeOptions) {
   const utils = trpc.useUtils();
 
-  return trpc.linksAnalyze.useMutation({
+  return trpc.hyperlinks.analyze.useMutation({
     ...options,
     onSuccess(data, variables, context) {
       // invalidate all queries on the link router

--- a/apps/client/src/services/hooks/useLinksFindAll.ts
+++ b/apps/client/src/services/hooks/useLinksFindAll.ts
@@ -1,11 +1,11 @@
 import { ReactQueryOptions, RouterInputs, trpc } from "@client/services/trpc";
 
-type LinkByIdOptions = ReactQueryOptions["linksFindAll"];
-type LinkByIdInput = RouterInputs["linksFindAll"];
+type LinkByIdOptions = ReactQueryOptions["hyperlinks"]["findAll"];
+type LinkByIdInput = RouterInputs["hyperlinks"]["findAll"];
 
 export function useLinksFindAll(
   input: LinkByIdInput,
-  options?: LinkByIdOptions
+  options?: LinkByIdOptions,
 ) {
-  return trpc.linksFindAll.useQuery(input, options);
+  return trpc.hyperlinks.findAll.useQuery(input, options);
 }

--- a/apps/client/src/services/hooks/useLogin.ts
+++ b/apps/client/src/services/hooks/useLogin.ts
@@ -6,12 +6,12 @@ import {
 } from "@client/services/trpc";
 import Cookies from "js-cookie";
 
-type LoginOptions = ReactQueryOptions["login"];
+type LoginOptions = ReactQueryOptions["auth"]["login"];
 
 export function useLogin(options?: LoginOptions) {
   const utils = trpc.useUtils();
 
-  return trpc.login.useMutation({
+  return trpc.auth.login.useMutation({
     ...options,
     onSuccess(data, variables, context) {
       // invalidate all queries on the link router

--- a/apps/client/src/services/hooks/useRegister.ts
+++ b/apps/client/src/services/hooks/useRegister.ts
@@ -5,12 +5,12 @@ import {
   type RouterOutputs,
 } from "@client/services/trpc";
 
-type RegisterOptions = ReactQueryOptions["register"];
+type RegisterOptions = ReactQueryOptions["auth"]["register"];
 
 export function useRegister(options?: RegisterOptions) {
   const utils = trpc.useUtils();
 
-  return trpc.register.useMutation({
+  return trpc.auth.register.useMutation({
     ...options,
     onSuccess(data, variables, context) {
       // invalidate all queries on the link router

--- a/apps/client/src/services/utils.ts
+++ b/apps/client/src/services/utils.ts
@@ -1,9 +1,9 @@
 import Cookies from "js-cookie";
 import { httpBatchLink } from "@trpc/client";
 import type { AppRouter } from "@server/trpc/trpc.router";
-import { createTRPCProxyClient } from "@trpc/react-query";
+import { createTRPCClient } from "@trpc/react-query";
 
-export const trcpProxyClient = createTRPCProxyClient<AppRouter>({
+export const trcpProxyClient = createTRPCClient<AppRouter>({
   links: [
     httpBatchLink({
       url: "http://localhost:4000/trpc",
@@ -14,13 +14,13 @@ export const trcpProxyClient = createTRPCProxyClient<AppRouter>({
 export async function handleTrpcUnauthError(
   res: Response,
   url: RequestInfo | URL,
-  options: any
+  options: any,
 ) {
   const { error } = await res.json();
   const refreshToken = Cookies.get("refresh_token");
   if (error.message === "jwt expired" && refreshToken) {
     try {
-      const refreshResponse = await trcpProxyClient.refresh.query({
+      const refreshResponse = await trcpProxyClient.auth.refresh.query({
         refresh_token: refreshToken,
       });
 

--- a/apps/server/src/links/links.service.ts
+++ b/apps/server/src/links/links.service.ts
@@ -17,7 +17,7 @@ export class LinksService {
     return this.linksRepository.find();
   }
 
-  async find(
+  async get(
     cursor: number,
     limit: number,
   ): Promise<{ data: Link[]; total: number }> {


### PR DESCRIPTION
* Separated app router: create `hyperlinks` & `auth` sub routers (apps/server/src/trpc/trpc.router.ts);
* Renamed links `find` to `get handler (apps/server/src/links/links.service.ts);
* Renamed authentication `signIn` to `login` handler (apps/server/src/auth/auth.service.ts);
* Created `register` authentication handler (apps/server/src/auth/auth.service.ts);
* Fixed `createTRPCClient`, due to `createTRPCProxyClient` is deprecated in tRPC v11 (apps/client/src/services/utils.ts);
* Updated frontend queries & mutations naming (apps/client/src/components/views/home/Home/Home.tsx, apps/client/src/services/hooks/useLinkCreate.ts, apps/client/src/services/hooks/useLinkFindById.ts, apps/client/src/services/hooks/useLinksAnalyze.ts, apps/client/src/services/hooks/useLinksFindAll.ts, apps/client/src/services/hooks/useLogin.ts, apps/client/src/services/hooks/useRegister.ts).