### PR TITLE
Fix tRPC client error: `body stream already read`

### DIFF
--- a/apps/client/src/components/views/register/Register/Register.tsx
+++ b/apps/client/src/components/views/register/Register/Register.tsx
@@ -29,7 +29,11 @@ const Register = () => {
 
   useEffect(() => {
     console.log("error:", register.error);
-  }, [register.error]);
+    setError("registerError", {
+      type: "custom",
+      message: register.error?.message,
+    });
+  }, [register.error, setError]);
 
   useEffect(() => {
     console.log("isPending:", register.isPending);

--- a/apps/client/src/services/utils.ts
+++ b/apps/client/src/services/utils.ts
@@ -16,7 +16,10 @@ export async function handleTrpcUnauthError(
   url: RequestInfo | URL,
   options: any,
 ) {
-  const { error } = await res.json();
+  const data = await res.json();
+  const error = data.error
+    ? data.error
+    : data[0].error; /* Todo: map data array */
   const refreshToken = Cookies.get("refresh_token");
   if (error.message === "jwt expired" && refreshToken) {
     try {
@@ -43,7 +46,7 @@ export async function handleTrpcUnauthError(
       Cookies.remove("refresh_token");
       return res;
     }
+  } else {
+    return await fetch(url, options);
   }
-
-  return res;
 }


### PR DESCRIPTION
* Update `handleTrpcUnauthError`: return awaited fetch when message don't equals `jwt expired` (apps/client/src/services/utils.ts);
* Update Register error handling: use `react-hook-form` setError hook (apps/client/src/components/views/register/Register/Register.tsx).