### PR TITLE
Replace `bull` with `bullmq`

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -35,7 +35,7 @@
     "@nestjs/typeorm": "^10.0.1",
     "@trpc/server": "11.0.0-next-beta.316",
     "bcrypt": "^5.1.1",
-    "bull": "^4.12.2",
+    "bullmq": "^5.4.5",
     "fastify": "^4.25.2",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.11.3",

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -1,6 +1,7 @@
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { FastifyAdapter } from '@bull-board/fastify';
 import { BullBoardModule } from '@bull-board/nestjs';
-import { BullModule } from '@nestjs/bull';
+import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -33,7 +34,7 @@ import { CollectionsModule } from './collections/collections.module';
       autoLoadEntities: true,
     }),
     BullModule.forRoot({
-      redis: {
+      connection: {
         host: 'localhost',
         password: 'password',
         port: 6379,
@@ -42,6 +43,10 @@ import { CollectionsModule } from './collections/collections.module';
     BullBoardModule.forRoot({
       route: '/queues',
       adapter: FastifyAdapter,
+    }),
+    BullBoardModule.forFeature({
+      name: 'links',
+      adapter: BullMQAdapter,
     }),
     CollectionsModule,
   ],

--- a/apps/server/src/links/links.module.ts
+++ b/apps/server/src/links/links.module.ts
@@ -3,7 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { LinksService } from '@server/links/links.service';
 import { Link } from '@server/links/link.entity';
 import { LinksProcessor } from '@server/links/links.processor';
-import { BullModule } from '@nestjs/bull';
+import { BullModule } from '@nestjs/bullmq';
 import { BullBoardModule } from '@bull-board/nestjs';
 import { BullAdapter } from '@bull-board/api/bullAdapter';
 import { TrpcService } from '@server/trpc/trpc.service';

--- a/apps/server/src/links/links.processor.ts
+++ b/apps/server/src/links/links.processor.ts
@@ -1,22 +1,25 @@
-import { Process, Processor } from '@nestjs/bull';
+import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Logger } from '@nestjs/common';
-import { Job } from 'bull';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { Link } from '@server/links/link.entity';
+import { Job } from 'bullmq';
+import { Repository } from 'typeorm';
 
 @Processor('links')
-export class LinksProcessor {
+export class LinksProcessor extends WorkerHost {
   constructor(
     @InjectRepository(Link)
     private linksRepository: Repository<Link>,
-  ) {}
+  ) {
+    super();
+  }
   private readonly logger = new Logger(LinksProcessor.name);
 
-  @Process('analyze')
-  async handleAnalyze(job: Job) {
+  // @Process('analyze')
+  async process(job: Job<any, any, string>, token?: string): Promise<any> {
     this.logger.debug('Start Analyze...');
     this.logger.debug(job.data);
+    this.logger.debug(token);
     const links = await this.linksRepository.find();
     this.logger.debug(links.length);
     this.logger.debug('End Analyze');

--- a/apps/server/src/links/links.service.ts
+++ b/apps/server/src/links/links.service.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Link } from '@server/links/link.entity';
-import { InjectQueue } from '@nestjs/bull';
-import { Queue } from 'bull';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
 
 @Injectable()
 export class LinksService {

--- a/apps/server/src/trpc/trpc.module.ts
+++ b/apps/server/src/trpc/trpc.module.ts
@@ -8,7 +8,7 @@ import { Link } from '@server/links/link.entity';
 import { User } from '@server/users/user.entity';
 import { UsersModule } from '@server/users/users.module';
 import { UsersService } from '@server/users/users.service';
-import { BullModule } from '@nestjs/bull';
+import { BullModule } from '@nestjs/bullmq';
 import { AuthModule } from '@server/auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,7 +124,7 @@ importers:
         version: 10.0.1(@nestjs/common@10.3.0)(@nestjs/core@10.3.0)(bull@4.12.2)
       '@nestjs/bullmq':
         specifier: ^10.1.0
-        version: 10.1.0(@nestjs/common@10.3.0)(@nestjs/core@10.3.0)(bullmq@5.4.3)
+        version: 10.1.0(@nestjs/common@10.3.0)(@nestjs/core@10.3.0)(bullmq@5.4.5)
       '@nestjs/common':
         specifier: ^10.0.0
         version: 10.3.0(reflect-metadata@0.1.14)(rxjs@7.8.1)
@@ -152,9 +152,9 @@ importers:
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1
-      bull:
-        specifier: ^4.12.2
-        version: 4.12.2
+      bullmq:
+        specifier: ^5.4.5
+        version: 5.4.5
       fastify:
         specifier: ^4.25.2
         version: 4.25.2
@@ -1461,7 +1461,7 @@ packages:
       tslib: 2.6.0
     dev: false
 
-  /@nestjs/bullmq@10.1.0(@nestjs/common@10.3.0)(@nestjs/core@10.3.0)(bullmq@5.4.3):
+  /@nestjs/bullmq@10.1.0(@nestjs/common@10.3.0)(@nestjs/core@10.3.0)(bullmq@5.4.5):
     resolution: {integrity: sha512-e4QD3JilyOZAddyQ4ABj0rX7T2Rr0OVx4KwJKWTpaEqNQhBP4yVLZbSdEY+GFu1HEE8NkV92Q8BJJdCxlVphSw==}
     peerDependencies:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
@@ -1471,7 +1471,7 @@ packages:
       '@nestjs/bull-shared': 10.1.0(@nestjs/common@10.3.0)(@nestjs/core@10.3.0)
       '@nestjs/common': 10.3.0(reflect-metadata@0.1.14)(rxjs@7.8.1)
       '@nestjs/core': 10.3.0(@nestjs/common@10.3.0)(@nestjs/platform-express@10.3.0)(reflect-metadata@0.1.14)(rxjs@7.8.1)
-      bullmq: 5.4.3
+      bullmq: 5.4.5
       tslib: 2.6.2
     dev: false
 
@@ -3033,8 +3033,8 @@ packages:
       - supports-color
     dev: false
 
-  /bullmq@5.4.3:
-    resolution: {integrity: sha512-JWzwAjX2LLn969W2R4ExoftOV646YX5rpB4q117vDaKYKT8cgAx+n94virnlLKVPK+X4WO8qSDJHzsiIepF2OA==}
+  /bullmq@5.4.5:
+    resolution: {integrity: sha512-0YQn4HYvII744VI+EGuR1SHOqHslouvbq52xrWob8bhjc5wYwolw1WoKD5w766bUHmEWCyFQCCxDPfQmmxKtnQ==}
     dependencies:
       cron-parser: 4.9.0
       ioredis: 5.3.2


### PR DESCRIPTION
* Install `bullmq` 5.4.5(apps/server/package.json, pnpm-lock.yaml);
* Remove `bull` 4.12.2(apps/server/package.json, pnpm-lock.yaml);
* Update `BullModule.forRoot` options: replace `redis` with `connection` (apps/server/src/app.module.ts);
* Add `BullBoardModule.forFeature` import: use `BullMQAdapter` (apps/server/src/app.module.ts);
* Update `Links` module: replace `@nestjs/bull'` with `@nestjs/bullmq` (apps/server/src/links/links.module.ts);
* Refactor `Links` processor: extends `LinksProcessor` class with `WorkerHost` (apps/server/src/links/links.processor.ts);
* Update `Links` service: replace `@nestjs/bull'` with `@nestjs/bullmq`  and `bull` with `bullmq` (apps/server/src/links/links.service.ts);
* Update `Trpc` module: replace `@nestjs/bull'` with `@nestjs/bullmq` (apps/server/src/trpc/trpc.module.ts);
* Update `Trpc` router: replace `OnGlobalQueueCompleted` with `OnQueueEvent` (apps/server/src/trpc/trpc.router.ts).