### PR TITLE
Update `Register` page & `useRegister` hook

### DIFF
--- a/apps/client/src/components/views/register/Register/Register.tsx
+++ b/apps/client/src/components/views/register/Register/Register.tsx
@@ -8,11 +8,13 @@ import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRegister } from "@client/services/hooks/useRegister";
 import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 const resolver = zodResolver(registerSchema);
 
 const Register = () => {
   const register = useRegister();
+  const router = useRouter();
 
   const {
     reset,
@@ -25,7 +27,10 @@ const Register = () => {
 
   useEffect(() => {
     console.log("data:", register.data);
-  }, [register.data]);
+    if (register.data?.access_token && register.data?.refresh_token) {
+      router.push("/");
+    }
+  }, [register.data, router]);
 
   useEffect(() => {
     console.log("error:", register.error);

--- a/apps/client/src/services/hooks/useRegister.ts
+++ b/apps/client/src/services/hooks/useRegister.ts
@@ -4,6 +4,7 @@ import {
   type RouterInputs,
   type RouterOutputs,
 } from "@client/services/trpc";
+import Cookies from "js-cookie";
 
 type RegisterOptions = ReactQueryOptions["auth"]["register"];
 
@@ -17,6 +18,10 @@ export function useRegister(options?: RegisterOptions) {
       // when a new link is created
       // utils.linkCreate.invalidate();
       // utils.linksFindAll.invalidate();
+      if (data?.access_token && data?.refresh_token) {
+        Cookies.set("access_token", data.access_token, { expires: 7 });
+        Cookies.set("refresh_token", data.refresh_token, { expires: 7 });
+      }
       utils.invalidate();
       options?.onSuccess?.(data, variables, context);
     },


### PR DESCRIPTION
* Update `useRegister` hook: save tokens to Cookies (apps/client/src/services/hooks/useRegister.ts);
* Update `Register` page: redirect to `Home` page after register (apps/client/src/components/views/register/Register/Register.tsx).