### PR TITLE
Add `metadata` procedure to hyperlinks route

### DIFF
--- a/apps/client/src/services/hooks/useLinkMetadata.ts
+++ b/apps/client/src/services/hooks/useLinkMetadata.ts
@@ -1,0 +1,24 @@
+import {
+  trpc,
+  type ReactQueryOptions,
+  // type RouterInputs,
+  // type RouterOutputs,
+} from "@client/services/trpc";
+
+type LinkMetadataOptions = ReactQueryOptions["hyperlinks"]["metadata"];
+
+export function useLinkMetadata(options?: LinkMetadataOptions) {
+  // const utils = trpc.useUtils();
+
+  return trpc.hyperlinks.metadata.useMutation({
+    ...options,
+    onSuccess(data, variables, context) {
+      // invalidate all queries on the link router
+      // when a new link is created
+      // utils.linkCreate.invalidate();
+      // utils.linksFindAll.invalidate();
+      // utils.invalidate();
+      options?.onSuccess?.(data, variables, context);
+    },
+  });
+}

--- a/apps/client/src/types/links.ts
+++ b/apps/client/src/types/links.ts
@@ -20,3 +20,17 @@ export const linkCreateSchema = z.object({
 export type LinkCreateFormSchema = z.infer<typeof linkCreateSchema> & {
   linkCreateError: string;
 };
+
+/**
+ * Metadata
+ */
+
+export const linkMetadataSchema = z.object({
+  url: z
+    .string()
+    .min(4, { message: "This field is required (min 4 characters)" }),
+});
+
+export type LinkMetadataFormSchema = z.infer<typeof linkMetadataSchema> & {
+  linkMetadataError: string;
+};

--- a/apps/server/src/links/links.processor.ts
+++ b/apps/server/src/links/links.processor.ts
@@ -17,12 +17,17 @@ export class LinksProcessor extends WorkerHost {
 
   // @Process('analyze')
   async process(job: Job<any, any, string>, token?: string): Promise<any> {
-    this.logger.debug('Start Analyze...');
-    this.logger.debug(job.data);
-    this.logger.debug(token);
-    const links = await this.linksRepository.find();
-    this.logger.debug(links.length);
-    this.logger.debug('End Analyze');
-    return job.data;
+    if (job.name === 'metadata') {
+      return job.data;
+    }
+    if (job.name === 'analyze') {
+      this.logger.debug('Start Analyze...');
+      this.logger.debug(job.data);
+      this.logger.debug(token);
+      const links = await this.linksRepository.find();
+      this.logger.debug(links.length);
+      this.logger.debug('End Analyze');
+      return job.data;
+    }
   }
 }

--- a/apps/server/src/links/links.service.ts
+++ b/apps/server/src/links/links.service.ts
@@ -73,4 +73,10 @@ export class LinksService {
     // TODO: return JobID
     return { status: 'start' };
   }
+
+  async metadata(url: string): Promise<{ data: any }> {
+    const job = await this.linksQueue.add('metadata', { url });
+    // TODO: return JobID
+    return { data: job };
+  }
 }

--- a/apps/server/src/trpc/trpc.router.ts
+++ b/apps/server/src/trpc/trpc.router.ts
@@ -105,6 +105,12 @@ export class TrpcRouter extends QueueEventsHost {
    * Links Router
    */
   hyperlinksRouter = this.trpc.router({
+    metadata: this.trpc.procedure
+      .input(z.object({ url: z.string() }))
+      .mutation(async ({ input }) => {
+        const { url } = input;
+        return await this.links.metadata(url);
+      }),
     analyze: this.trpc.procedure
       .input(z.object({ id: z.number(), type: z.string() }))
       .mutation(async ({ input }) => {
@@ -183,6 +189,7 @@ export class TrpcRouter extends QueueEventsHost {
   /**
    * App Router
    */
+  // TODO: ctx
   appRouter = this.trpc.router({
     auth: this.authRouter,
     hyperlinks: this.hyperlinksRouter,


### PR DESCRIPTION
* Update `LinkCreate`: add handler for `metadata` (apps/client/src/components/template/LinkCreate/LinkCreate.tsx);
* Create `useLinkMetadata` hook (apps/client/src/services/hooks/useLinkMetadata.ts);
* Add `linkMetadataSchema` & `LinkMetadataFormSchema` for metadata procedure (apps/client/src/types/links.ts);
* Conditionally execute `LinksProcessor` by job name (apps/server/src/links/links.processor.ts);
* Create `metadata` handler for `LinksService` (apps/server/src/links/links.service.ts);
* Create `metadata` for `hyperlinksRouter` (apps/server/src/trpc/trpc.router.ts).